### PR TITLE
feat(app): wire API into home database; show habit details in viewer

### DIFF
--- a/app/src/main/java/com/mpieterse/stride/ui/layout/central/roots/HomeNavGraph.kt
+++ b/app/src/main/java/com/mpieterse/stride/ui/layout/central/roots/HomeNavGraph.kt
@@ -3,8 +3,10 @@ package com.mpieterse.stride.ui.layout.central.roots
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.mpieterse.stride.ui.layout.central.views.DebugScreen
 import com.mpieterse.stride.ui.layout.central.views.HabitViewerScreen
 import com.mpieterse.stride.ui.layout.central.views.HomeDatabaseScreen
@@ -22,13 +24,11 @@ fun HomeNavGraph(
         startDestination = currentDestination
     ) {
         // Database
-        composable(
-            route = HomeScreen.Database.route
-        ) {
+        composable(route = HomeScreen.Database.route) {
             HomeDatabaseScreen(
                 modifier = modifier,
-                onNavigateToHabitViewer = {
-                    controller.navigate(HomeScreen.HabitViewer.route)
+                onNavigateToHabitViewer = { id ->
+                    controller.navigate(HomeScreen.HabitViewer.buildRoute(id))
                 }
             )
         }
@@ -56,13 +56,14 @@ fun HomeNavGraph(
 
         // HabitViewer
         composable(
-            route = HomeScreen.HabitViewer.route
-        ) {
+            route = HomeScreen.HabitViewer.route,  // "habit/{habitId}"
+            arguments = listOf(navArgument("habitId") { type = NavType.StringType })
+        ) { backStackEntry ->
+            val habitId = backStackEntry.arguments?.getString("habitId") ?: return@composable
             HabitViewerScreen(
                 modifier = modifier,
-                onBackClick = {
-                    controller.popBackStack()
-                }
+                habitId = habitId,
+                onBackClick = { controller.popBackStack() }
             )
         }
 

--- a/app/src/main/java/com/mpieterse/stride/ui/layout/central/roots/HomeScreen.kt
+++ b/app/src/main/java/com/mpieterse/stride/ui/layout/central/roots/HomeScreen.kt
@@ -3,12 +3,16 @@ package com.mpieterse.stride.ui.layout.central.roots
 /**
  * Logical alias for [HomeActivity] screen routes.
  */
-sealed class HomeScreen(
-    val route: String
-) {
-    object Database : HomeScreen("database")
+
+sealed class HomeScreen(val route: String) {
+    object Database      : HomeScreen("database")
     object Notifications : HomeScreen("notifications")
-    object Settings : HomeScreen("settings")
-    object HabitViewer : HomeScreen("habitViewer")
-    object Debug : HomeScreen("debug")
+    object Settings      : HomeScreen("settings")
+
+    // pattern with argument
+    object HabitViewer   : HomeScreen("habit/{habitId}") {
+        fun buildRoute(habitId: String) = "habit/$habitId"
+    }
+
+    object Debug         : HomeScreen("debug")
 }

--- a/app/src/main/java/com/mpieterse/stride/ui/layout/central/viewmodels/HabitViewerViewModel.kt
+++ b/app/src/main/java/com/mpieterse/stride/ui/layout/central/viewmodels/HabitViewerViewModel.kt
@@ -1,0 +1,105 @@
+// HabitViewerViewModel.kt
+package com.mpieterse.stride.ui.layout.central.viewmodels
+
+import android.graphics.Bitmap
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.mpieterse.stride.core.net.ApiResult
+import com.mpieterse.stride.data.dto.checkins.CheckInDto
+import com.mpieterse.stride.data.dto.habits.HabitDto
+import com.mpieterse.stride.data.repo.CheckInRepository
+import com.mpieterse.stride.data.repo.HabitRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.time.*
+
+@HiltViewModel
+class HabitViewerViewModel @Inject constructor(
+    private val habits: HabitRepository,
+    private val checkins: CheckInRepository
+) : ViewModel() {
+
+    data class UiState(
+        val loading: Boolean = true,
+        val error: String? = null,
+        val habitName: String = "",
+        val habitImage: Bitmap? = null,
+        val streakDays: Int = 0,
+        val completedDates: List<Int> = emptyList()
+    )
+
+    private val _state = MutableStateFlow(UiState())
+    val state: StateFlow<UiState> = _state
+
+    fun load(habitId: String) = viewModelScope.launch {
+        _state.value = _state.value.copy(loading = true, error = null)
+
+        val habitName = when (val hr = habits.list()) {
+            is ApiResult.Ok<*> -> (hr.data as List<*>)
+                .filterIsInstance<HabitDto>()
+                .firstOrNull { it.id == habitId }?.name ?: "(Unknown habit)"
+            is ApiResult.Err -> {
+                _state.value = _state.value.copy(
+                    loading = false,
+                    error = "Habit load failed: ${hr.code ?: ""} ${hr.message ?: ""}"
+                )
+                return@launch
+            }
+        }
+
+        val mine: List<CheckInDto> = when (val cr = checkins.list()) {
+            is ApiResult.Ok<*> -> (cr.data as List<*>)
+                .filterIsInstance<CheckInDto>()
+                .filter { it.habitId == habitId }
+            is ApiResult.Err -> {
+                _state.value = _state.value.copy(
+                    loading = false,
+                    habitName = habitName,
+                    error = "Check-ins load failed: ${cr.code ?: ""} ${cr.message ?: ""}"
+                )
+                return@launch
+            }
+        }
+
+        val today = LocalDate.now()
+        val monthStart = today.withDayOfMonth(1)
+        val completedThisMonth = mine.mapNotNull { it.completedAt.toLocalDateOrNull() }
+            .filter { it.year == monthStart.year && it.month == monthStart.month }
+            .map { it.dayOfMonth }
+            .distinct()
+            .sorted()
+
+        val streak = computeStreakDays(mine.mapNotNull { it.completedAt.toLocalDateOrNull() }.distinct())
+
+        _state.value = _state.value.copy(
+            loading = false,
+            habitName = habitName,
+            streakDays = streak,
+            completedDates = completedThisMonth
+        )
+    }
+
+    // Count consecutive days ending today.
+    private fun computeStreakDays(dates: List<LocalDate>): Int {
+        if (dates.isEmpty()) return 0
+        val set = dates.toHashSet()
+        var d = LocalDate.now()
+        var streak = 0
+        while (set.contains(d)) {
+            streak++
+            d = d.minusDays(1)
+        }
+        return streak
+    }
+
+    private fun String.toLocalDateOrNull(): LocalDate? {
+        return try {
+            Instant.parse(this).atZone(ZoneId.systemDefault()).toLocalDate()
+        } catch (_: Exception) {
+            try { LocalDate.parse(this) } catch (_: Exception) { null }
+        }
+    }
+}

--- a/app/src/main/java/com/mpieterse/stride/ui/layout/central/viewmodels/HomeDatabaseViewModel.kt
+++ b/app/src/main/java/com/mpieterse/stride/ui/layout/central/viewmodels/HomeDatabaseViewModel.kt
@@ -1,9 +1,66 @@
 package com.mpieterse.stride.ui.layout.central.viewmodels
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.mpieterse.stride.core.net.ApiResult
+import com.mpieterse.stride.data.repo.HabitRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
-class HomeDatabaseViewModel : ViewModel() {
-    companion object {
-        private const val TAG = "DatabaseViewModel"
+@HiltViewModel
+class HomeDatabaseViewModel @Inject constructor(
+    private val habitsRepo: HabitRepository,
+) : ViewModel() {
+
+    data class HabitRowUi(
+        val id: String,
+        val name: String,
+        val tag: String = "Habit",                 // <- default chip text
+        val progress: Float = 0f,
+        val checklist: List<Boolean> = emptyList(),
+        val streaked: Boolean = false,
+    )
+
+    data class UiState(
+        val loading: Boolean = false,
+        val habits: List<HabitRowUi> = emptyList(),
+        val daysHeader: List<String> = listOf("SUN\n19", "SAT\n18", "FRI\n17"),
+        val error: String? = null
+    )
+
+    private val _state = MutableStateFlow(UiState(loading = true))
+    val state: StateFlow<UiState> = _state
+
+    init {
+        refresh()
+    }
+
+    fun refresh() = viewModelScope.launch {
+        _state.value = _state.value.copy(loading = true, error = null)
+        when (val r = habitsRepo.list()) {
+            is ApiResult.Ok<*> -> {
+                val items = (r.data as List<*>).mapNotNull { any ->
+                    val dto = any as? com.mpieterse.stride.data.dto.habits.HabitDto ?: return@mapNotNull null
+                    HabitRowUi(
+                        id = dto.id,
+                        name = dto.name,
+                        tag = "Habit",                      // <- remove dto.tag usage
+                        progress = 0f,
+                        checklist = listOf(false, false, false),
+                        streaked = false
+                    )
+                }
+                _state.value = _state.value.copy(loading = false, habits = items)
+            }
+            is ApiResult.Err -> {
+                _state.value = _state.value.copy(
+                    loading = false,
+                    error = "${r.code ?: ""} ${r.message ?: "Unknown error"}"
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/mpieterse/stride/ui/layout/central/viewmodels/HomeSettingsViewModel.kt
+++ b/app/src/main/java/com/mpieterse/stride/ui/layout/central/viewmodels/HomeSettingsViewModel.kt
@@ -11,72 +11,113 @@ import com.mpieterse.stride.core.models.configuration.options.SyncFrequency
 import com.mpieterse.stride.core.models.configuration.schema.ConfigurationSchema
 import com.mpieterse.stride.core.services.ConfigurationService
 import com.mpieterse.stride.core.utils.Clogger
+import com.mpieterse.stride.core.net.ApiResult
+import com.mpieterse.stride.data.dto.settings.SettingsDto
+import com.mpieterse.stride.data.repo.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class HomeSettingsViewModel @Inject constructor(
-    private val configService: ConfigurationService
+    private val configService: ConfigurationService,
+    private val settingsRepo: SettingsRepository,
 ) : ViewModel() {
-    companion object {
-        private const val TAG = "HomeSettingsViewModel"
-    }
 
+    companion object { private const val TAG = "HomeSettingsViewModel" }
 
-// --- Functions
-
-
+    // UI state
     var theme by mutableStateOf(AppAppearance.LIGHT)
         private set
-
-
-    var notifications by mutableStateOf(AlertFrequency.ALL)
+    var notifications by mutableStateOf(AlertFrequency.ALL)  // local-only
+        private set
+    var sync by mutableStateOf(SyncFrequency.ALWAYS)         // local-only
         private set
 
-
-    var sync by mutableStateOf(SyncFrequency.ALWAYS)
+    var loading by mutableStateOf(false)
         private set
-
+    var error by mutableStateOf<String?>(null)
+        private set
 
     init {
+        // Load cached values fast, then hydrate theme from API
         viewModelScope.launch {
             theme = configService.get(ConfigurationSchema.appAppearance)
             notifications = configService.get(ConfigurationSchema.alertFrequency)
             sync = configService.get(ConfigurationSchema.syncFrequency)
+            fetchFromApi()
         }
     }
 
+    // ---- Public updaters ----
 
     fun updateTheme(value: AppAppearance) {
         theme = value
-        viewModelScope.launch { 
-            configService.put(ConfigurationSchema.appAppearance, value)
-            Clogger.i(
-                TAG, "Theme set to $value"
-            )
-        }
+        viewModelScope.launch { configService.put(ConfigurationSchema.appAppearance, value) }
+        pushThemeToApi()
     }
-
 
     fun updateAlerts(value: AlertFrequency) {
         notifications = value
-        viewModelScope.launch { 
-            configService.put(ConfigurationSchema.alertFrequency, value)
-            Clogger.i(
-                TAG, "Notifications set to $value"
-            )
-        }
+        viewModelScope.launch { configService.put(ConfigurationSchema.alertFrequency, value) }
+        // API does not support notifications field — local only.
     }
-
 
     fun updateSync(value: SyncFrequency) {
         sync = value
-        viewModelScope.launch { 
-            configService.put(ConfigurationSchema.syncFrequency, value)
-            Clogger.i(
-                TAG, "Sync set to $value"
-            )
+        viewModelScope.launch { configService.put(ConfigurationSchema.syncFrequency, value) }
+        Clogger.i(TAG, "Sync set to $value")
+    }
+
+    // ---- API bridge (theme only) ----
+
+    private fun pushThemeToApi() = viewModelScope.launch {
+        val apiTheme = theme.toApiTheme()
+        loading = true; error = null
+        when (val r = settingsRepo.update(SettingsDto(dailyReminderHour = null, theme = apiTheme))) {
+            is ApiResult.Ok -> {
+                loading = false
+                Clogger.i(TAG, "Settings updated on server: theme=$apiTheme")
+            }
+            is ApiResult.Err -> {
+                loading = false
+                error = "${r.code ?: ""} ${r.message ?: "Update failed"}"
+                Clogger.e(TAG, "Update failed: $error")
+            }
         }
+    }
+
+    private fun fetchFromApi() = viewModelScope.launch {
+        loading = true; error = null
+        when (val r = settingsRepo.get()) {
+            is ApiResult.Ok -> {
+                loading = false
+                val dto = r.data
+                val uiTheme = dto.theme?.toUiTheme() ?: theme
+                theme = uiTheme
+                // cache theme locally
+                configService.put(ConfigurationSchema.appAppearance, uiTheme)
+                Clogger.i(TAG, "Fetched settings from server: $dto")
+            }
+            is ApiResult.Err -> {
+                loading = false
+                error = "${r.code ?: ""} ${r.message ?: "Load failed"}"
+                Clogger.w(TAG, "Using cached settings; server fetch failed: $error")
+            }
+        }
+    }
+
+    // ---- Mappers ----
+
+    private fun AppAppearance.toApiTheme(): String = when (this) {
+        AppAppearance.LIGHT -> "light"
+        AppAppearance.NIGHT -> "dark"
+        AppAppearance.SYSTEM -> "system"
+    }
+
+    private fun String.toUiTheme(): AppAppearance = when (lowercase()) {
+        "light" -> AppAppearance.LIGHT
+        "dark"  -> AppAppearance.NIGHT
+        else    -> AppAppearance.SYSTEM
     }
 }

--- a/app/src/main/java/com/mpieterse/stride/ui/layout/central/views/HabitViewerScreen.kt
+++ b/app/src/main/java/com/mpieterse/stride/ui/layout/central/views/HabitViewerScreen.kt
@@ -1,34 +1,18 @@
 package com.mpieterse.stride.ui.layout.central.views
 
+import android.graphics.Bitmap
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -40,152 +24,106 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mpieterse.stride.R
 import com.mpieterse.stride.ui.layout.central.components.UpsertDialog
-import com.mpieterse.stride.ui.layout.shared.components.LocalStyledActivityStatusBar
+import com.mpieterse.stride.ui.layout.central.viewmodels.HabitViewerViewModel
 import java.time.LocalDate
 
 @Composable
 fun HabitViewerScreen(
-    habitName: String = "Go to the gym",
-    habitImage: android.graphics.Bitmap? = null,
-    streakDays: Int = 265,
-    completedDates: List<Int> = listOf(8, 18, 19, 28, 29, 30),
+    habitId: String,
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit = {}
 ) {
+    val vm: HabitViewerViewModel = hiltViewModel()
+    val state by vm.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(habitId) { vm.load(habitId) }
+
     var showEditDialog by remember { mutableStateOf(false) }
-    
-    // Local state for habit data (functional without database)
-    var currentHabitName by remember { mutableStateOf(habitName) }
-    var currentHabitImage by remember { mutableStateOf(habitImage) }
-    var currentStreakDays by remember { mutableStateOf(streakDays) }
-    var currentCompletedDates by remember { mutableStateOf(completedDates) }
-    
-    // Sample habit data for editing
-    val habitData = com.mpieterse.stride.ui.layout.central.components.HabitData(
-        name = currentHabitName,
-        frequency = 3, // days per week
-        tag = "Health & Fitness",
-        image = currentHabitImage
-    )
+
+    // mirror VM state locally for edit preview (no API write yet)
+    var currentHabitName by remember(state.habitName) { mutableStateOf(state.habitName) }
+    var currentHabitImage by remember(state.habitImage) { mutableStateOf<Bitmap?>(state.habitImage) }
+    var currentStreakDays by remember(state.streakDays) { mutableStateOf(state.streakDays) }
+    var currentCompletedDates by remember(state.completedDates) { mutableStateOf(state.completedDates) }
 
     Box(modifier = modifier.fillMaxSize()) {
-        // Main content
-        Column(
-            modifier = Modifier.fillMaxSize()
-        ) {
-            // Top Bar
-            Surface(
-                color = Color.White,
-                modifier = Modifier.fillMaxWidth()
-            ) {
+        Column(Modifier.fillMaxSize()) {
+
+            // Top bar
+            Surface(color = Color.White, modifier = Modifier.fillMaxWidth()) {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    IconButton(
-                        onClick = onBackClick,
-                        modifier = Modifier.size(24.dp)
-                    ) {
+                    IconButton(onClick = onBackClick, modifier = Modifier.size(24.dp)) {
                         Icon(
                             painter = painterResource(R.drawable.xic_uic_outline_arrow_left),
                             contentDescription = "Back",
                             tint = Color.Black
                         )
                     }
-                    
                     Text(
-                        text = currentHabitName,
+                        text = if (state.loading) "Loading…" else currentHabitName,
                         style = MaterialTheme.typography.headlineSmall.copy(
                             fontWeight = FontWeight.Bold,
                             fontSize = 20.sp
                         ),
-                        color = Color.Black,
+                        color = if (state.error != null) MaterialTheme.colorScheme.error else Color.Black,
                         modifier = Modifier
                             .weight(1f)
                             .padding(horizontal = 16.dp),
                         textAlign = TextAlign.Center
                     )
-                    
-                    // Empty space to balance the back button
-                    Spacer(modifier = Modifier.width(48.dp))
+                    Spacer(Modifier.width(48.dp))
                 }
             }
-            
-            // Main Content
-            Surface(
-                color = Color.White,
-                modifier = Modifier.fillMaxSize()
-            ) {
+
+            // Main content
+            Surface(color = Color.White, modifier = Modifier.fillMaxSize()) {
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(16.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    // Habit Image
                     HabitImageViewer(
                         habitImage = currentHabitImage,
                         modifier = Modifier.fillMaxWidth()
                     )
-                    
-                    // Streak Banner
+
                     StreakBanner(
                         streakDays = currentStreakDays,
                         modifier = Modifier.fillMaxWidth()
                     )
-                    
-                    // Calendar Section
+
                     CalendarView(
                         completedDates = currentCompletedDates,
                         modifier = Modifier.fillMaxWidth(),
                         onDateClick = { day ->
-                            // Toggle completion status for the day
-                            currentCompletedDates = if (day in currentCompletedDates) {
-                                currentCompletedDates.filter { it != day }
-                            } else {
-                                currentCompletedDates + day
-                            }
+                            currentCompletedDates =
+                                if (day in currentCompletedDates) currentCompletedDates - day
+                                else currentCompletedDates + day
                         }
                     )
+
+                    if (state.error != null) {
+                        Text(
+                            text = state.error!!,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
                 }
             }
         }
-        
-        // Bottom Action Bar
-        Surface(
-            color = Color.White,
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth()
-        ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                IconButton(
-                    onClick = { /* Achievement/Awards action */ }
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.xic_uic_outline_shield_check),
-                        contentDescription = "Achievements",
-                        tint = Color.Gray,
-                        modifier = Modifier.size(24.dp)
-                    )
-                }
-                
-                // Empty space for FAB
-                Spacer(modifier = Modifier.width(56.dp))
-            }
-        }
-        
-        // Floating Action Button
+
+        // Edit FAB
         FloatingActionButton(
             onClick = { showEditDialog = true },
             containerColor = Color(0xFFFF9500),
@@ -203,26 +141,30 @@ fun HabitViewerScreen(
         }
     }
 
-    // Edit Dialog
+    // Edit dialog (local-only)
     UpsertDialog(
         title = "Edit Habit",
         isVisible = showEditDialog,
         onDismiss = { showEditDialog = false },
-        onConfirm = { updatedData ->
-            // Update local state with edited data
-            currentHabitName = updatedData.name
-            currentHabitImage = updatedData.image
-            // Keep streak and completed dates as they are (these would be calculated differently in real app)
-            println("Updated habit: ${updatedData.name}")
+        onConfirm = { updated ->
+            currentHabitName = updated.name
+            currentHabitImage = updated.image
             showEditDialog = false
         },
-        initialData = habitData
+        initialData = com.mpieterse.stride.ui.layout.central.components.HabitData(
+            name = currentHabitName,
+            frequency = 3,
+            tag = "Health & Fitness",
+            image = currentHabitImage
+        )
     )
 }
 
+/* ---------- Helpers ---------- */
+
 @Composable
 private fun HabitImageViewer(
-    habitImage: android.graphics.Bitmap?,
+    habitImage: Bitmap?,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -241,10 +183,7 @@ private fun HabitImageViewer(
                 contentScale = ContentScale.Crop
             )
         } else {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 Text(
                     text = "(IMAGE)",
                     style = MaterialTheme.typography.bodyLarge.copy(
@@ -288,27 +227,15 @@ private fun CalendarView(
     onDateClick: (Int) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
-        // Days of week header
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
         DaysOfWeekHeader()
-        
-        // Calendar grid
-        CalendarGrid(
-            completedDates = completedDates,
-            onDateClick = onDateClick
-        )
+        CalendarGrid(completedDates = completedDates, onDateClick = onDateClick)
     }
 }
 
 @Composable
-private fun DaysOfWeekHeader(
-    modifier: Modifier = Modifier
-) {
+private fun DaysOfWeekHeader(modifier: Modifier = Modifier) {
     val daysOfWeek = listOf("MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN")
-    
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceEvenly
@@ -334,41 +261,26 @@ private fun CalendarGrid(
     onDateClick: (Int) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
-    // Generate calendar for current month (October 2024 based on your design)
-    val currentMonth = LocalDate.of(2024, 10, 1)
-    val firstDayOfMonth = currentMonth.dayOfWeek.value % 7 // Convert to 0-6 (Sunday = 0)
+    val currentMonth = LocalDate.now().withDayOfMonth(1)
+    val firstDayOfMonth = currentMonth.dayOfWeek.value % 7
     val daysInMonth = currentMonth.lengthOfMonth()
-    
-    // Calculate calendar grid
+
     val calendarDays = mutableListOf<List<Int?>>()
-    
-    // First week - fill empty spaces before month starts
-    val firstWeek = mutableListOf<Int?>()
-    repeat(firstDayOfMonth) { firstWeek.add(null) }
-    for (day in 1..(7 - firstDayOfMonth)) {
-        firstWeek.add(day)
-    }
+    val firstWeek = MutableList(firstDayOfMonth) { null as Int? }
+    for (d in 1..(7 - firstDayOfMonth)) firstWeek.add(d)
     calendarDays.add(firstWeek)
-    
-    // Remaining weeks
+
     var currentDay = 8 - firstDayOfMonth
     while (currentDay <= daysInMonth) {
-        val week = mutableListOf<Int?>()
-        repeat(7) { dayIndex ->
-            if (currentDay + dayIndex <= daysInMonth) {
-                week.add(currentDay + dayIndex)
-            } else {
-                week.add(null)
-            }
+        val week = MutableList(7) { idx ->
+            val day = currentDay + idx
+            if (day <= daysInMonth) day else null
         }
         calendarDays.add(week)
         currentDay += 7
     }
-    
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
+
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
         calendarDays.forEach { week ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -378,11 +290,7 @@ private fun CalendarGrid(
                     Box(
                         modifier = Modifier
                             .size(32.dp)
-                            .clickable { 
-                                if (day != null) {
-                                    onDateClick(day)
-                                }
-                            },
+                            .clickable { if (day != null) onDateClick(day) },
                         contentAlignment = Alignment.Center
                     ) {
                         if (day != null) {


### PR DESCRIPTION
-HomeDatabaseScreen now calls backend and lists created habits (API happy path working). -HabitViewerScreen loads by habitId and displays the habit name from API. -Nav graph updated to pass concrete habit routes (habit/{habitId} ➜ habit/<id>). Known gaps / next steps:
-Day streak logic not correct; cannot complete days for a habit yet. -“Create Habit” action on Database screen not implemented (only works in Debug). -Notifications screen is seeded/static.
-Habit edit flow not wired to API.